### PR TITLE
Repair table layout

### DIFF
--- a/product-definitions/input-to-draft-regulation.md
+++ b/product-definitions/input-to-draft-regulation.md
@@ -290,9 +290,7 @@
       </td>
       <td>The inclusion of the terms "distribution", "validation", and "storage" appears to broaden the scope beyond the issuance/signing side of a PKI (as signified by "Public key infrastructure and digital certificate issuance software"). It even appears to encompass "relying parties" (the software that consumes PKI contents). This broad reading of the scope is possible because of the inclusion of these terms, but also because the first sentence does not distinguish between PDEs that manage private versus public cryptographic key material.</td>
       <td>The words "distribution", "validation" and "storage" should probably be removed.
-
           For additional clarity, the second sentence could be amended by adding something like: ", but excludes relying parties."
-
           Finally, the first sentence could be amended to read "asymetric cryptographic private keys"</td>
     </tr>
     <tr>


### PR DESCRIPTION
Empty lines trigger markdown processing, breaking the table layout. Remove them.